### PR TITLE
fix: replace removed nixpkgs attrs in devops-env-c and language shells

### DIFF
--- a/lib/languages/default.nix
+++ b/lib/languages/default.nix
@@ -11,7 +11,7 @@
   bash = {
     packages = with pkgs; [
       bashInteractive
-      nodePackages.bash-language-server
+      bash-language-server
       shellcheck
       shfmt
     ];
@@ -38,9 +38,9 @@
   nodejs = {
     packages = with pkgs; [
       nodejs
-      nodePackages.eslint
-      nodePackages.typescript
-      nodePackages.typescript-language-server
+      eslint
+      typescript
+      typescript-language-server
       yarn
     ];
   };

--- a/pkgs/devops-env-c/default.nix
+++ b/pkgs/devops-env-c/default.nix
@@ -26,9 +26,8 @@ pkgs.buildEnv {
     lazygit
     less
     neovim
-    nodePackages.bash-language-server
+    bash-language-server
     ripgrep
-    silver-searcher
     starship
     tmux
     tree


### PR DESCRIPTION
nodePackages.* is gone from nixpkgs-unstable; use top-level attrs instead (bash-language-server, eslint, typescript, typescript-language-server). Drop silver-searcher from devops-env-c — removed upstream; ripgrep remains.