### PR TITLE
ci: drop macos-13 from flake check matrix

### DIFF
--- a/.github/workflows/nix-flake-check.yml
+++ b/.github/workflows/nix-flake-check.yml
@@ -17,9 +17,6 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          # TBI: aarch64-macos
-          # - macos-latest
-          - macos-13
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Linux-only CI for now; macOS runners were unused.