### PR TITLE
ci: add macos-latest to flake check matrix

### DIFF
--- a/.github/workflows/nix-flake-check.yml
+++ b/.github/workflows/nix-flake-check.yml
@@ -17,6 +17,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
+          - macos-latest
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Run flake check on Apple Silicon alongside ubuntu-latest.