### PR TITLE
ci: modernize workflows and automate flake.lock updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/nix-flake-check.yml
+++ b/.github/workflows/nix-flake-check.yml
@@ -5,12 +5,17 @@ on:
     branches:
       - master
   pull_request:
-    branches:
-      - '*'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   check:
+    name: flake check (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 90
 
     strategy:
       fail-fast: false
@@ -19,13 +24,16 @@ jobs:
           - ubuntu-latest
           - macos-latest
 
+    permissions:
+      contents: read
+
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - name: Setup Nix
-        uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/determinate-nix-action@v3
 
-      - name: Run Nix Flake Check
-        # devenv needs devenv-root
-        run: nix flake check --override-input devenv-root "file+file://"<(printf %s "$PWD")
+      - uses: DeterminateSystems/flake-checker-action@v12
+
+      - name: Run Nix flake check
+        # devenv needs devenv-root as an absolute path
+        run: nix flake check --override-input devenv-root "file+file://${{ github.workspace }}"

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -1,0 +1,27 @@
+name: Update flake.lock
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 6 * * 1"
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: DeterminateSystems/determinate-nix-action@v3
+
+      - uses: DeterminateSystems/update-flake-lock@v28
+        with:
+          pr-title: "chore: update flake.lock"
+          pr-labels: |
+            dependencies
+            automated


### PR DESCRIPTION
Rebased on master (includes #12 `macos-latest`).

## Flake check workflow

- Pin `actions/checkout@v4`, `determinate-nix-action@v3`, and `flake-checker-action@v12` (replaces floating `nix-installer-action@main`)
- Add concurrency, job timeouts, minimal permissions, and `workflow_dispatch`
- Pass `devenv-root` via `${{ github.workspace }}` instead of shell process substitution
- Per-OS job names for clearer CI logs

## Maintenance

- Weekly `update-flake-lock` workflow (Mondays 06:00 UTC; manual trigger available)
- Group dependabot github-actions bumps into single weekly PRs

## Not in scope

- FlakeHub cache (needs account setup)
- Explicit per-package build checks for the new Mermaid CLIs